### PR TITLE
Relocate Kotlin in the jar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ tasks {
         relocate("net.kyori", "com.hibiscusmc.hmccolor.kyori")
         relocate("org.spongepowered.configurate", "com.hibiscusmc.hmccolor.configurate")
         relocate("org.bstats", "com.hibiscusmc.hmccolor.bstats")
+        relocate("kotlin", "com.hibiscusmc.hmccolor.kotlin")
         archiveFileName.set("HMCColor.jar")
     }
 


### PR DESCRIPTION
This fixes issues with other plugins such as Eco with their own Kotlin in their jars, causing problems for HMCColor. 